### PR TITLE
Human-readable storage alias names via `alias_decodes` (GSI-1564)

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -5,4 +5,7 @@ ucs_api_url: http://127.0.0.1/upload
 storage_aliases:
   storage1: http://127.0.0.1/object_storage_1
   storage2: http://127.0.0.1/object_storage_2
+alias_decodes:
+  HD01: Heidelberg
+  TUE01: Tübingen
 service_instance_id: "001"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--check]
         pass_filenames: false
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wkvs"
-version = "1.1.3"
+version = "1.2.0"
 description = "Well-Known-Value-Service - Provides access to common values via API"
 dependencies = [
     "ghga-service-commons[api]>=4.0.0",

--- a/README.md
+++ b/README.md
@@ -95,7 +95,11 @@ The service requires the following configuration parameters:
 
 - <a id="properties/storage_aliases"></a>**`storage_aliases`** *(object, required)*: Mapping of storage alias to endpoint URL for all available S3 object storages. Can contain additional properties.
 
+  - <a id="properties/storage_aliases/additionalProperties"></a>**Additional properties** *(string)*
+
 - <a id="properties/alias_decodes"></a>**`alias_decodes`** *(object, required)*: Mapping of storage alias to its human-readable format. Can contain additional properties.
+
+  - <a id="properties/alias_decodes/additionalProperties"></a>**Additional properties** *(string)*
 
 
   Examples:

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/well-known-value-service):
 ```bash
-docker pull ghga/well-known-value-service:1.1.3
+docker pull ghga/well-known-value-service:1.2.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/well-known-value-service:1.1.3 .
+docker build -t ghga/well-known-value-service:1.2.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -31,7 +31,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/well-known-value-service:1.1.3 --help
+docker run -p 8080:8080 ghga/well-known-value-service:1.2.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -94,6 +94,19 @@ The service requires the following configuration parameters:
 - <a id="properties/wps_api_url"></a>**`wps_api_url`** *(string, required)*: URL to the root of the WPS API.
 
 - <a id="properties/storage_aliases"></a>**`storage_aliases`** *(object, required)*: Mapping of storage alias to endpoint URL for all available S3 object storages. Can contain additional properties.
+
+- <a id="properties/alias_decodes"></a>**`alias_decodes`** *(object, required)*: Mapping of storage alias to its human-readable format. Can contain additional properties.
+
+
+  Examples:
+
+  ```json
+  {
+      "HD01": "Heidelberg",
+      "TUE01": "T\u00fcbingen"
+  }
+  ```
+
 
 - <a id="properties/host"></a>**`host`** *(string)*: IP of the host. Default: `"127.0.0.1"`.
 

--- a/config_schema.json
+++ b/config_schema.json
@@ -73,13 +73,17 @@
       "type": "string"
     },
     "storage_aliases": {
-      "additionalProperties": true,
+      "additionalProperties": {
+        "type": "string"
+      },
       "description": "Mapping of storage alias to endpoint URL for all available S3 object storages",
       "title": "Storage Aliases",
       "type": "object"
     },
     "alias_decodes": {
-      "additionalProperties": true,
+      "additionalProperties": {
+        "type": "string"
+      },
       "description": "Mapping of storage alias to its human-readable format",
       "examples": [
         {

--- a/config_schema.json
+++ b/config_schema.json
@@ -78,6 +78,18 @@
       "title": "Storage Aliases",
       "type": "object"
     },
+    "alias_decodes": {
+      "additionalProperties": true,
+      "description": "Mapping of storage alias to its human-readable format",
+      "examples": [
+        {
+          "HD01": "Heidelberg",
+          "TUE01": "T\u00fcbingen"
+        }
+      ],
+      "title": "Alias Decodes",
+      "type": "object"
+    },
     "host": {
       "default": "127.0.0.1",
       "description": "IP of the host.",
@@ -218,7 +230,8 @@
     "dcs_api_url",
     "ucs_api_url",
     "wps_api_url",
-    "storage_aliases"
+    "storage_aliases",
+    "alias_decodes"
   ],
   "title": "ModSettings",
   "type": "object"

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,3 +1,6 @@
+alias_decodes:
+  HD01: Heidelberg
+  TUE01: "T\xFCbingen"
 api_root_path: ''
 auto_reload: false
 cors_allow_credentials: null

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,7 +33,7 @@ components:
 info:
   description: A service providing well known values.
   title: Well Known Values Service
-  version: 1.1.3
+  version: 1.2.0
 openapi: 3.1.0
 paths:
   /health:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "wkvs"
-version = "1.1.3"
+version = "1.2.0"
 description = "Well-Known-Value-Service - Provides access to common values via API"
 dependencies = [
     "ghga-service-commons[api]>=4.0.0",

--- a/src/wkvs/config.py
+++ b/src/wkvs/config.py
@@ -38,6 +38,11 @@ class WellKnownConfig(BaseSettings):
         ...,
         description="Mapping of storage alias to endpoint URL for all available S3 object storages",
     )
+    alias_decodes: dict = Field(
+        ...,
+        description="Mapping of storage alias to its human-readable format",
+        examples=[{"HD01": "Heidelberg", "TUE01": "Tübingen"}],
+    )
 
 
 SERVICE_NAME: str = "wkvs"

--- a/src/wkvs/config.py
+++ b/src/wkvs/config.py
@@ -34,11 +34,11 @@ class WellKnownConfig(BaseSettings):
         description="URL to the root of the upload controller API.",
     )
     wps_api_url: str = Field(..., description="URL to the root of the WPS API.")
-    storage_aliases: dict = Field(
+    storage_aliases: dict[str, str] = Field(
         ...,
         description="Mapping of storage alias to endpoint URL for all available S3 object storages",
     )
-    alias_decodes: dict = Field(
+    alias_decodes: dict[str, str] = Field(
         ...,
         description="Mapping of storage alias to its human-readable format",
         examples=[{"HD01": "Heidelberg", "TUE01": "Tübingen"}],

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -5,4 +5,7 @@ ucs_api_url: http://127.0.0.1/upload
 storage_aliases:
   storage1: http://127.0.0.1/object_storage_1
   storage2: http://127.0.0.1/object_storage_2
+alias_decodes:
+  HD01: Heidelberg
+  TUE01: Tübingen
 service_instance_id: "001"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,8 +20,9 @@ from fastapi import status
 
 from tests.fixtures.joint import JointFixture, joint_fixture  # noqa: F401
 
+pytestmark = pytest.mark.asyncio()
 
-@pytest.mark.asyncio
+
 async def test_health_check(joint_fixture: JointFixture):  # noqa: F811
     """Test that the health check endpoint works."""
     response = await joint_fixture.rest_client.get("/health")
@@ -30,7 +31,6 @@ async def test_health_check(joint_fixture: JointFixture):  # noqa: F811
     assert response.json() == {"status": "OK"}
 
 
-@pytest.mark.asyncio
 async def test_happy_retrieval(joint_fixture: JointFixture):  # noqa: F811
     """Test that configured values can be retrieved"""
     url = "/values/crypt4gh_public_key"
@@ -48,7 +48,6 @@ async def test_happy_retrieval(joint_fixture: JointFixture):  # noqa: F811
         "service_name",  # existing config value that shouldn't be retrievable
     ],
 )
-@pytest.mark.asyncio
 async def test_non_configured_value(
     joint_fixture: JointFixture,  # noqa: F811
     value_name: str,
@@ -60,7 +59,6 @@ async def test_non_configured_value(
     assert response.json()["detail"] == f"The value {value_name} is not configured"
 
 
-@pytest.mark.asyncio
 async def test_retrieve_all_values(joint_fixture: JointFixture):  # noqa: F811
     """Test that the all-values endpoint works"""
     response = await joint_fixture.rest_client.get("/values")
@@ -74,4 +72,5 @@ async def test_retrieve_all_values(joint_fixture: JointFixture):  # noqa: F811
             "storage1": "http://127.0.0.1/object_storage_1",
             "storage2": "http://127.0.0.1/object_storage_2",
         },
+        "alias_decodes": {"HD01": "Heidelberg", "TUE01": "Tübingen"},
     }


### PR DESCRIPTION
This adds a dict value called `alias_decodes` where the keys are the abbreviated storage alias labels, e.g. `TUE01`, and the values are the corresponding human-readable values, e.g. `Tübingen`.